### PR TITLE
Support HKLM\Software\Policies\Syncthing

### DIFF
--- a/SourceDir/syncthing_upgrade.cmd
+++ b/SourceDir/syncthing_upgrade.cmd
@@ -125,7 +125,7 @@ call :editConfigXml "<crashReportingEnabled>.*<\/crashReportingEnabled>" "<crash
 REM 
 REM 	Usage Reporting
 IF "%enableTelemetry%" == "0" SET PROPERTY_UR_ACCEPTED=-1
-IF "%enableTelemetry%" == "1" SET PROPERTY_UR_ACCEPTED=1
+IF "%enableTelemetry%" == "1" SET PROPERTY_UR_ACCEPTED=3
 call :editConfigXml "<urAccepted>.*<\/urAccepted>" "<urAccepted>%PROPERTY_UR_ACCEPTED%</urAccepted>"
 call :editConfigXml "<urSeen>.*<\/urSeen>" "<urSeen>3</urSeen>"
 REM

--- a/SourceDir/syncthing_upgrade.cmd
+++ b/SourceDir/syncthing_upgrade.cmd
@@ -278,6 +278,8 @@ call :editConfigXml "<startBrowser>true<\/startBrowser>" "<startBrowser>false</s
 REM
 REM 	defaults: folder
 call :editConfigXml "(.*<folder id=\`\` label=\`.*\` path=)\`~\`" "$1 `%SystemDrive%\Server\Sync`"
+REM
+call :setDefaultFolderIgnorePerms
 REM 
 REM Perform ongoing config maintenance.
 call :regQueryToVar "%REG_SYNCTHING%" "setDevicenameToComputername" "REG_SZ" "setDevicenameToComputername"
@@ -448,6 +450,15 @@ for /f "tokens=3* delims= " %%A in ('reg query "%TMP_RQTV_REG_KEY%" /v "%TMP_RQT
 IF NOT DEFINED %TMP_RQTV_REG_ENTRY_ENV_VAR% call :logAdd "[WARN] regQueryToVar: Failed query [%TMP_RQTV_REG_KEY%]:[%TMP_RQTV_REG_ENTRY_NAME%]:[%TMP_RQTV_REG_ENTRY_TYPE%]." & SET "REG_QUERIES_SUCCEEDED=0" &goto :eof
 call :logAdd "[INFO] regQueryToVar: Got %TMP_RQTV_REG_ENTRY_ENV_VAR%=[%%%TMP_RQTV_REG_ENTRY_ENV_VAR%%%]"
 REM 
+goto :eof
+
+
+:setDefaultFolderIgnorePerms
+REM
+SET CONFIG_XML_NQ=%CONFIG_XML:"=%
+REM
+powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $defaultFolderNode = $xml.SelectSingleNode('//configuration/defaults/folder'); $defaultFolderNode.SetAttribute('ignorePerms', 'true'); $xml.Save($ENV:CONFIG_XML_NQ);"
+REM
 goto :eof
 
 

--- a/SourceDir/syncthing_upgrade.cmd
+++ b/SourceDir/syncthing_upgrade.cmd
@@ -148,7 +148,7 @@ IF NOT DEFINED defaultVersioningMode SET defaultVersioningMode=none
 REM
 SET CONFIG_XML_NQ=%CONFIG_XML:"=%
 REM
-powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $versioningNode.type = $ENV:defaultVersioningMode; $xml.Save($ENV:CONFIG_XML_NQ);"
+powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $versioningNode.SetAttribute('type', $ENV:defaultVersioningMode); $xml.Save($ENV:CONFIG_XML_NQ);"
 REM
 IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); if ($paramNode -eq $null) { $versioningNode.AppendChild($xml.CreateElement('param')) }; $xml.Save($ENV:CONFIG_XML_NQ);"
 REM

--- a/SourceDir/syncthing_upgrade.cmd
+++ b/SourceDir/syncthing_upgrade.cmd
@@ -148,11 +148,11 @@ IF NOT DEFINED defaultVersioningMode SET defaultVersioningMode=none
 REM
 SET CONFIG_XML_NQ=%CONFIG_XML:"=%
 REM
-powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $versioningNode.SetAttribute('type', $ENV:defaultVersioningMode); $xml.Save($ENV:CONFIG_XML_NQ);"
+powershell -ExecutionPolicy ByPass "$xml = New-Object XML; $xml.PreserveWhitespace = $true; $xml.Load('%CONFIG_XML%'); $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $versioningNode.SetAttribute('type', $ENV:defaultVersioningMode); $xml.Save('%CONFIG_XML%');"
 REM
-IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); if ($paramNode -eq $null) { $versioningNode.AppendChild($xml.CreateElement('param')) | Out-Null }; $xml.Save($ENV:CONFIG_XML_NQ);"
+IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "$xml = New-Object XML; $xml.PreserveWhitespace = $true; $xml.Load('%CONFIG_XML%'); $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); if ($paramNode -eq $null) { $versioningNode.AppendChild($xml.CreateElement('param')) | Out-Null }; $xml.Save('%CONFIG_XML%');"
 REM
-IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); $paramNode.SetAttribute('key', 'cleanoutDays'); $paramNode.SetAttribute('val', '90'); $xml.Save($ENV:CONFIG_XML_NQ);"
+IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "$xml = New-Object XML; $xml.PreserveWhitespace = $true; $xml.Load('%CONFIG_XML%'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); $paramNode.SetAttribute('key', 'cleanoutDays'); $paramNode.SetAttribute('val', '90'); $xml.Save('%CONFIG_XML%');"
 REM
 goto :eof
 
@@ -457,7 +457,7 @@ goto :eof
 REM
 SET CONFIG_XML_NQ=%CONFIG_XML:"=%
 REM
-powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $defaultFolderNode = $xml.SelectSingleNode('//configuration/defaults/folder'); $defaultFolderNode.SetAttribute('ignorePerms', 'true'); $xml.Save($ENV:CONFIG_XML_NQ);"
+powershell -ExecutionPolicy ByPass "$xml = New-Object XML; $xml.PreserveWhitespace = $true; $xml.Load('%CONFIG_XML%'); $defaultFolderNode = $xml.SelectSingleNode('//configuration/defaults/folder'); $defaultFolderNode.SetAttribute('ignorePerms', 'true'); $xml.Save('%CONFIG_XML%');"
 REM
 goto :eof
 

--- a/SourceDir/syncthing_upgrade.cmd
+++ b/SourceDir/syncthing_upgrade.cmd
@@ -152,7 +152,7 @@ powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; 
 REM
 IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); if ($paramNode -eq $null) { $versioningNode.AppendChild($xml.CreateElement('param')) | Out-Null }; $xml.Save($ENV:CONFIG_XML_NQ);"
 REM
-IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); $paramNode.SetAttribute('key', 'cleanoutdays'); $paramNode.SetAttribute('val', '90'); $xml.Save($ENV:CONFIG_XML_NQ);"
+IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); $paramNode.SetAttribute('key', 'cleanoutDays'); $paramNode.SetAttribute('val', '90'); $xml.Save($ENV:CONFIG_XML_NQ);"
 REM
 goto :eof
 

--- a/SourceDir/syncthing_upgrade.cmd
+++ b/SourceDir/syncthing_upgrade.cmd
@@ -150,7 +150,7 @@ SET CONFIG_XML_NQ=%CONFIG_XML:"=%
 REM
 powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $versioningNode.SetAttribute('type', $ENV:defaultVersioningMode); $xml.Save($ENV:CONFIG_XML_NQ);"
 REM
-IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); if ($paramNode -eq $null) { $versioningNode.AppendChild($xml.CreateElement('param')) }; $xml.Save($ENV:CONFIG_XML_NQ);"
+IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $versioningNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning'); $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); if ($paramNode -eq $null) { $versioningNode.AppendChild($xml.CreateElement('param')) | Out-Null }; $xml.Save($ENV:CONFIG_XML_NQ);"
 REM
 IF "%defaultVersioningMode%" == "trashcan" powershell -ExecutionPolicy ByPass "[xml]$xml = Get-Content $ENV:CONFIG_XML_NQ; $paramNode = $xml.SelectSingleNode('//configuration/defaults/folder/versioning/param'); $paramNode.SetAttribute('key', 'cleanoutdays'); $paramNode.SetAttribute('val', '90'); $xml.Save($ENV:CONFIG_XML_NQ);"
 REM

--- a/Syncthing.wxs.template
+++ b/Syncthing.wxs.template
@@ -36,26 +36,8 @@
 
 		<Property Id='ARPPRODUCTICON' Value='ApplicationIcon' />
 		
-		<!-- App specific properties -->
-		<!-- Leave ADD_DEVICE_HOST at the pre-defined value if you do not need to enroll a new device -->
-		<Property Id='ADD_DEVICE_HOST' Value='localhost.localdomain' />
-		<Property Id='ADD_DEVICE_ID' Value='CF6WMOG-F4RHVKW-2FTJONJ-GJ3FZQS-YW5TJVW-VDDT6ZQ-EVJ2WDP-RL4QZQO' />
-		<Property Id='ADD_DEVICE_PORT' Value='22000' />
-		<Property Id='crashReportingEnabled' Value='false' />
-		<Property Id='DATA_PORT' Value='22000' />
-		<Property Id='globalAnnounceEnabled' Value='true' />
-		<Property Id='hashers' Value='0' />
-		<Property Id='localAnnounceEnabled' Value='true' />
-		<Property Id='natEnabled' Value='true' />
-		<Property Id='OVERRIDE_DEVICE_NAME_WITH_COMPUTERNAME' Value='1' />
-		<Property Id='OVERRIDE_EXISTING_CONFIG' Value='0' />
-		<Property Id='relaysEnabled' Value='true' />
-		<Property Id='REMOTE_WEB_UI' Value='0' />
 		<!-- SERVICE_ACCOUNT options: LOCALSERVICE, NETWORKSERVICE, SYSTEM -->
 		<Property Id='SERVICE_ACCOUNT' Value='LOCALSERVICE' />
-		<Property Id='STNOUPGRADE' Value='1' />
-		<Property Id='urAccepted' Value='-1' />
-		<Property Id='WEB_UI_PORT' Value='8384' />
 
 		<DirectoryRef Id="ApplicationProgramsFolder">
 			<Component Id="ApplicationShortcut" Guid="*">
@@ -111,26 +93,6 @@
                 <RegistryKey Root="HKLM" Key="Software\[Manufacturer]\[ProductName]">
                     <RegistryValue Name="Version" Value="[ProductVersion]" Type="string" />
                 </RegistryKey>
-                
-                <!-- App specific properties -->
-                <RegistryKey Root="HKLM" Key="Software\[Manufacturer]\[ProductName]">
-					<RegistryValue Name="ADD_DEVICE_HOST" Value="[ADD_DEVICE_HOST]" Type="string" />
-					<RegistryValue Name="ADD_DEVICE_ID" Value="[ADD_DEVICE_ID]" Type="string" />
-					<RegistryValue Name="ADD_DEVICE_PORT" Value="[ADD_DEVICE_PORT]" Type="string" />
-					<RegistryValue Name="crashReportingEnabled" Value="[crashReportingEnabled]" Type="string" />
-					<RegistryValue Name="DATA_PORT" Value="[DATA_PORT]" Type="string" />
-					<RegistryValue Name="globalAnnounceEnabled" Value="[globalAnnounceEnabled]" Type="string" />
-					<RegistryValue Name="hashers" Value="[hashers]" Type="string" />
-					<RegistryValue Name="localAnnounceEnabled" Value="[localAnnounceEnabled]" Type="string" />
-					<RegistryValue Name="natEnabled" Value="[natEnabled]" Type="string" />
-					<RegistryValue Name="OVERRIDE_DEVICE_NAME_WITH_COMPUTERNAME" Value="[OVERRIDE_DEVICE_NAME_WITH_COMPUTERNAME]" Type="string" />
-					<RegistryValue Name="OVERRIDE_EXISTING_CONFIG" Value="[OVERRIDE_EXISTING_CONFIG]" Type="string" />
-					<RegistryValue Name="relaysEnabled" Value="[relaysEnabled]" Type="string" />
-					<RegistryValue Name="REMOTE_WEB_UI" Value="[REMOTE_WEB_UI]" Type="string" />
-					<RegistryValue Name="STNOUPGRADE" Value="[STNOUPGRADE]" Type="string" />
-					<RegistryValue Name="urAccepted" Value="[urAccepted]" Type="string" />
-					<RegistryValue Name="WEB_UI_PORT" Value="[WEB_UI_PORT]" Type="string" />
-                </RegistryKey>
             </Component>
         </DirectoryRef>
         
@@ -153,7 +115,7 @@
         <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" />
         
 		<CustomAction 
-			Id="ExecSyncthingUpgradeCmd" 
+			Id="ExecUpgradeCmd" 
 			Directory='ServerSyncthingDir' 
 			Execute='deferred' 
 			Impersonate='no' 
@@ -161,9 +123,9 @@
 			Return='check'/>
 
 		<CustomAction 
-			Id="ExecSyncthingRemoveCmd" 
+			Id="ExecRemoveCmd" 
 			Directory='ServerSyncthingDir' 
-			Execute='immediate' 
+			Execute='deferred' 
 			Impersonate='no' 
 			ExeCommand='[ServerSyncthingDir]syncthing_remove.cmd' 
 			Return='check'/>
@@ -177,8 +139,8 @@
             </Custom>
             -->
             <RemoveExistingProducts Before="InstallInitialize" />
-            <Custom Action="ExecSyncthingUpgradeCmd" After="WriteRegistryValues">NOT REMOVE</Custom>
-            <Custom Action="ExecSyncthingRemoveCmd" Before="InstallFiles">REMOVE</Custom>
+            <Custom Action="ExecUpgradeCmd" After="WriteRegistryValues">NOT REMOVE</Custom>
+            <Custom Action="ExecRemoveCmd" Before="RemoveFiles">REMOVE</Custom>
             <LaunchConditions After="AppSearch"/>
         </InstallExecuteSequence>
 


### PR DESCRIPTION
Example are written on install to:
HKLM\Software\Policies\Syncthing\Example

The policies are applied on INSTALL/UPGRADE.
Future plan: They will be applied on every start of the service.

EXAMPLE with default settings:
* If a setting does not exist in the registry, its default value is used. Just set some you really need.
```
@echo off
REG ADD "HKLM\Software\Policies\Syncthing" /v "addDeviceHost" /t REG_SZ /d "localhost.localdomain" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "addDeviceID" /t REG_SZ /d "CF6WMOG-F4RHVKW-2FTJONJ-GJ3FZQS-YW5TJVW-VDDT6ZQ-EVJ2WDP-RL4QZQO" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "addDevicePort" /t REG_SZ /d "22000" /f >NUL:
REM
REG ADD "HKLM\Software\Policies\Syncthing" /v "dataTcpPort" /t REG_SZ /d "22000" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "defaultVersioningMode" /t REG_SZ /d "none" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableAutoUpgrade" /t REG_SZ /d "1" /f >NUL:
REM
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableGlobalDiscovery" /t REG_SZ /d "1" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableLocalDiscovery" /t REG_SZ /d "1" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableNAT" /t REG_SZ /d "1" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableRelays" /t REG_SZ /d "1" /f >NUL:
REM
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableRemoteWebUi" /t REG_SZ /d "0" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "enableTelemetry" /t REG_SZ /d "1" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "hashers" /t REG_SZ /d "0" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "setDevicenameToComputername" /t REG_SZ /d "1" /f >NUL:
REG ADD "HKLM\Software\Policies\Syncthing" /v "webUiTcpPort" /t REG_SZ /d "8384" /f >NUL:
```
